### PR TITLE
Create sad path for projects query and happy path for projects query

### DIFF
--- a/app.test.js
+++ b/app.test.js
@@ -26,6 +26,23 @@ describe('Server', () => {
         // expectation
         expect(projects).toEqual(expectedProjects)
       })
+
+      it('should return the correct project if there is a name query parameter', async () => {
+        const expectedProject = await database('projects').first().select();
+        expectedProject.created_at = expectedProject.created_at.toJSON();
+        expectedProject.updated_at = expectedProject.updated_at.toJSON();
+
+        const response = await request(app).get('/api/v1/projects?name=T');
+        
+        expect(response.status).toBe(200);
+        expect(response.body[0]).toEqual(expectedProject);
+      })
+
+      it('should return a 404 error if the name in the query parameter does not match any project names', async () => {
+        const response = await request(app).get('/api/v1/projects?name=noproject')
+        expect(response.status).toBe(404)
+      })
+
       it('should return all the palettes in the DB', async () => {
         const expectedPalettes = await database('palettes').select()
         expectedPalettes.forEach(palette => {


### PR DESCRIPTION

# Description
Add sad paths test for projects GET endpoint and happy query test for projects GET


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:
`Your message here`


## Has This Been Tested?

- [ ] No
- [X] Yes

# Checklist:

- [X] My code has no unused/commented out code
- [X] My code has no console logs
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas